### PR TITLE
helm chart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "workbench.colorTheme": "Default Dark+", 
+    "workbench.iconTheme": "vscode-icons",    
+    "editor.defaultFormatter": "esbenp.prettier-vscode", 
+    "vs-kubernetes": {
+        "vs-kubernetes.kubeconfig": "/scm/kubeconfig.yaml"
+    },
+    "workbench.sideBar.location": "right"
+} 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Default settings will be generated and placed in the `/home/steam/.avorion/galax
 
 If you enable RCON in `settings.ini`, make sure you also forward the port in docker (`-p 27015:27015`).
 
+### Helm
+
+```
+helm install avorion charts/avorion
+```
+
 ## Docker Images
 
 The `latest` tag will follow the latest [avorion server][1] release

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you enable RCON in `settings.ini`, make sure you also forward the port in doc
 ### Helm
 
 ```
-helm install avorion charts/avorion
+helm install avorion --set hostname=<your preferred host> charts/avorion
 ```
 
 ## Docker Images

--- a/charts/avorion/.helmignore
+++ b/charts/avorion/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/avorion/Chart.yaml
+++ b/charts/avorion/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: avorion
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/avorion/templates/NOTES.txt
+++ b/charts/avorion/templates/NOTES.txt
@@ -1,0 +1,1 @@
+This is a Helm chart for Avorion.

--- a/charts/avorion/templates/_helpers.tpl
+++ b/charts/avorion/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "avorion.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "avorion.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "avorion.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "avorion.labels" -}}
+helm.sh/chart: {{ include "avorion.chart" . }}
+{{ include "avorion.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "avorion.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "avorion.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "avorion.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "avorion.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/avorion/templates/avorion-service-tcp.yaml
+++ b/charts/avorion/templates/avorion-service-tcp.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: avorion-tcp
+spec:
+  type: LoadBalancer
+  ports:
+    - name: "27000"
+      port: 27000
+      targetPort: 27000
+  selector:
+    app: avorion
+status:
+  loadBalancer: {}

--- a/charts/avorion/templates/avorion-service-udp.yaml
+++ b/charts/avorion/templates/avorion-service-udp.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: avorion-udp
+spec:
+  type: LoadBalancer
+  ports:
+    - name: 27000-udp
+      port: 27000
+      protocol: UDP
+      targetPort: 27000
+    - name: "27003"
+      port: 27003
+      protocol: UDP
+      targetPort: 27003
+    - name: "27020"
+      port: 27020
+      protocol: UDP
+      targetPort: 27020
+    - name: "27021"
+      port: 27021
+      protocol: UDP
+      targetPort: 27021
+  selector:
+    app: avorion
+status:
+  loadBalancer: {}

--- a/charts/avorion/templates/avorion-statefulset.yaml
+++ b/charts/avorion/templates/avorion-statefulset.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: avorion
+  name: avorion
+spec:
+  serviceName: "avorion"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: avorion
+  template:
+    metadata:
+      labels:
+        app: avorion  
+    spec:
+      {{- if .Values.hostname }}
+      nodeSelector:
+        kubernetes.io/hostname: {{ .Values.hostname }}
+      {{- end }}
+      containers:
+        - image: rfvgyhn/avorion:stable
+          name: avorion
+          ports:
+            - containerPort: 27000
+            - containerPort: 27000
+              protocol: UDP
+            - containerPort: 27003
+              protocol: UDP
+            - containerPort: 27020
+              protocol: UDP
+            - containerPort: 27021
+              protocol: UDP
+          resources: {}
+          volumeMounts:
+            - mountPath: /home/steam/.avorion/galaxies/avorion_galaxy
+              name: galaxy
+      restartPolicy: Always
+  volumeClaimTemplates:
+  - metadata:
+      name: galaxy
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi

--- a/charts/avorion/templates/avorion-statefulset.yaml
+++ b/charts/avorion/templates/avorion-statefulset.yaml
@@ -16,8 +16,15 @@ spec:
         app: avorion  
     spec:
       {{- if .Values.hostname }}
-      nodeSelector:
-        kubernetes.io/hostname: {{ .Values.hostname }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                  - {{ .Values.hostname }}      
       {{- end }}
       containers:
         - image: rfvgyhn/avorion:stable


### PR DESCRIPTION
This pull requests adds a [Helm](https://helm.sh) chart so that Avorion can be hosted in a [Kubernetes](https://kubernetes.io) cluster.
- I've added a property to allow the user to choose which node they want the stateful set to run on (seeing that Avorion is monolithic).
- There is no way to customize server settings. I think we could try mounting a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) over the settings file if we want config to be a Kubernetes resource.
- I've tested this on my [K3S](https://k3s.io) home-lab cluster against `Avorion 1.3.8 2e6faba21eb9`. Please email me or respond on this PR if you would like to connect.
- We can create a [GitHub Pages](https://medium.com/containerum/how-to-make-and-share-your-own-helm-package-50ae40f6c221) location to host to Helm chart for public use and update the README to show how to install it. For now, we assume the user is cloning the repo.

Thanks for the awesome work with this image! 🚀